### PR TITLE
(bugfix) clickhousemetricsexporter: runtime error: index out of range

### DIFF
--- a/exporter/clickhousemetricsexporter/helper.go
+++ b/exporter/clickhousemetricsexporter/helper.go
@@ -394,13 +394,14 @@ func addSingleHistogramDataPoint(pt pdata.HistogramDataPoint, resource pdata.Res
 		bucketBounds = append(bucketBounds, bucketBoundsData{sig: sig, bound: bound})
 	}
 	// add le=+Inf bucket
-	cumulativeCount += pt.BucketCounts()[len(pt.BucketCounts())-1]
 	infBucket := &prompb.Sample{
-		Value:     float64(cumulativeCount),
 		Timestamp: time,
 	}
 	if pt.Flags().HasFlag(pdata.MetricDataPointFlagNoRecordedValue) {
 		infBucket.Value = math.Float64frombits(value.StaleNaN)
+	} else {
+		cumulativeCount += pt.BucketCounts()[len(pt.BucketCounts())-1]
+		infBucket.Value = float64(cumulativeCount)
 	}
 	infLabels := createAttributes(resource, pt.Attributes(), externalLabels, nameStr, baseName+bucketStr, leStr, pInfStr)
 	sig := addSample(tsMap, infBucket, infLabels, metric)


### PR DESCRIPTION
Fixes #771 

Count the `+Inf` only when the point doesn't have `MetricDataPointFlagNoRecordedValue` set. The buckets become zero when the metric is considered as stale and cause the index out of range error.