### PR TITLE
Update ClickHouse connection setting to sane defaults

### DIFF
--- a/exporter/clickhousemetricsexporter/clickhouse.go
+++ b/exporter/clickhousemetricsexporter/clickhouse.go
@@ -116,9 +116,11 @@ func NewClickHouse(params *ClickHouseParams) (base.Storage, error) {
 	// fmt.Println(options)
 	initDB := clickhouse.OpenDB(options)
 
-	initDB.SetConnMaxIdleTime(2)
 	initDB.SetMaxOpenConns(params.MaxOpenConns)
-	initDB.SetConnMaxLifetime(0)
+	initDB.SetConnMaxLifetime(5 * time.Minute)
+	l.Info("initDB options", options)
+	l.Info("initDb", initDB)
+	l.Info(initDB.Stats())
 
 	if err != nil {
 		fmt.Errorf("Could not connect to clickhouse: ", err)
@@ -258,8 +260,9 @@ func (ch *clickHouse) Write(ctx context.Context, data *prompb.WriteRequest) erro
 		fingerprints[i] = f
 		timeSeries[f] = labels
 	}
+	ch.l.Infof("got %d fingerprints, but only %d of them were unique time series", len(fingerprints), len(timeSeries))
 	if len(fingerprints) != len(timeSeries) {
-		ch.l.Debugf("got %d fingerprints, but only %d of them were unique time series", len(fingerprints), len(timeSeries))
+		ch.l.Infof("got %d fingerprints, but only %d of them were unique time series", len(fingerprints), len(timeSeries))
 	}
 
 	// find new time series

--- a/exporter/clickhousemetricsexporter/clickhouse.go
+++ b/exporter/clickhousemetricsexporter/clickhouse.go
@@ -113,9 +113,7 @@ func NewClickHouse(params *ClickHouseParams) (base.Storage, error) {
 
 		options.Auth = auth
 	}
-	// fmt.Println(options)
 	initDB := clickhouse.OpenDB(options)
-	initDB.SetConnMaxIdleTime(10 * time.Minute)
 	initDB.SetMaxOpenConns(params.MaxOpenConns)
 	initDB.SetConnMaxLifetime(1 * time.Hour)
 

--- a/exporter/clickhousemetricsexporter/clickhouse.go
+++ b/exporter/clickhousemetricsexporter/clickhouse.go
@@ -115,12 +115,9 @@ func NewClickHouse(params *ClickHouseParams) (base.Storage, error) {
 	}
 	// fmt.Println(options)
 	initDB := clickhouse.OpenDB(options)
-
+	initDB.SetConnMaxIdleTime(10 * time.Minute)
 	initDB.SetMaxOpenConns(params.MaxOpenConns)
-	initDB.SetConnMaxLifetime(5 * time.Minute)
-	l.Info("initDB options", options)
-	l.Info("initDb", initDB)
-	l.Info(initDB.Stats())
+	initDB.SetConnMaxLifetime(1 * time.Hour)
 
 	if err != nil {
 		fmt.Errorf("Could not connect to clickhouse: ", err)
@@ -260,9 +257,8 @@ func (ch *clickHouse) Write(ctx context.Context, data *prompb.WriteRequest) erro
 		fingerprints[i] = f
 		timeSeries[f] = labels
 	}
-	ch.l.Infof("got %d fingerprints, but only %d of them were unique time series", len(fingerprints), len(timeSeries))
 	if len(fingerprints) != len(timeSeries) {
-		ch.l.Infof("got %d fingerprints, but only %d of them were unique time series", len(fingerprints), len(timeSeries))
+		ch.l.Debugf("got %d fingerprints, but only %d of them were unique time series", len(fingerprints), len(timeSeries))
 	}
 
 	// find new time series


### PR DESCRIPTION
ClickHouse closes the connection after an amount of time 1 Hour. We set `SetConnMaxIdleTime` to value 2 i.e 2ns meaning the connection get closed as soon as the become idle. And following we set `SetConnMaxLifetime` to 0 indicating that connections should never be closed which is contradicting. This gets us state of producing the weird issues. 