### PR TITLE
fix: invalid memory reference

### DIFF
--- a/exporter/clickhousemetricsexporter/exporter.go
+++ b/exporter/clickhousemetricsexporter/exporter.go
@@ -141,7 +141,10 @@ func (prwe *PrwExporter) PushMetrics(ctx context.Context, md pdata.Metrics) erro
 					if ok := validateMetrics(metric); !ok {
 						dropped++
 						errs = multierr.Append(errs, consumererror.NewPermanent(errors.New("invalid temporality and type combination")))
-						serviceName, _ := resource.Attributes().Get("service.name")
+						serviceName, found := resource.Attributes().Get("service.name")
+						if !found {
+							serviceName = pdata.NewAttributeValueString("<missing-svc>")
+						}
 						metricType := metric.DataType()
 						var numDataPoints int
 						var temporality pdata.MetricAggregationTemporality


### PR DESCRIPTION
The telemetry received from SDKs must send service name. If not configured it will be unknown_service. This may not always be true for other components which is causing the nil serive and panic
